### PR TITLE
Add GamepadConnected, GamepadDisconnected to Game.cs

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -181,6 +181,18 @@ namespace MoonWorks
 		protected virtual void DropBegin() {}
 		protected virtual void DropComplete() {}
 
+		/// <summary>
+		/// Called when a game pad has been connected.
+		/// </summary>
+		/// <param name="slot">The slot where the connection occurred.</param>
+		protected virtual void GamepadConnected(int slot) {}
+
+		/// <summary>
+		/// Called when a game pad has been disconnected.
+		/// </summary>
+		/// <param name="slot">The slot where the disconnection occurred.</param>
+		protected virtual void GamepadDisconnected(int slot) {}
+
 		private void Tick()
 		{
 			AdvanceElapsedTime();
@@ -343,12 +355,15 @@ namespace MoonWorks
 				Logger.LogInfo("New controller detected!");
 				Inputs.AddGamepad(index);
 			}
+			GamepadConnected(index);
 		}
 
 		private void HandleControllerRemoved(SDL.SDL_Event evt)
 		{
+			int index = evt.cdevice.which;
 			Logger.LogInfo("Controller removal detected!");
-			Inputs.RemoveGamepad(evt.cdevice.which);
+			Inputs.RemoveGamepad(index);
+			GamepadDisconnected(index);
 		}
 
 		public static void ShowRuntimeError(string title, string message)


### PR DESCRIPTION
This PR adds two virtual methods for state changes with Gamepads. The value in this provides detection at a higher level, allowing one to quickly add/remove options relating to game pads, input bindings, etc.

- GamepadConnected(int)
  - Called when a gamepad has been connected. Provides the slot number where the connection occurred.

- GamepadDisconnected(int)
  - Called when a gamepad has been disconnected. Provides the slot number where the disconnection occurred.

NOTE: At the moment, these two methods will be called regardless if the Gamepad (de)registration was a success. I'm unsure if this behavior would be desired.