### PR TITLE
Native zlib compression through IRO

### DIFF
--- a/src/Graphics/Bindings.cs
+++ b/src/Graphics/Bindings.cs
@@ -1669,6 +1669,28 @@ internal static partial class IRO
 		uint w,
 		uint h
 	);
+
+	[LibraryImport(nativeLibName)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	public static partial IntPtr IRO_Compress(
+		IntPtr data,
+		uint dataLength,
+		out uint outLength
+	);
+
+	[LibraryImport(nativeLibName)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	public static partial IntPtr IRO_Decompress(
+		IntPtr data,
+		uint dataLength,
+		out uint outLength
+	);
+
+	[LibraryImport(nativeLibName)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	public static partial void IRO_FreeBuffer(
+		IntPtr buffer
+	);
 }
 
 internal static partial class SDL_ShaderCross

--- a/src/Graphics/Bindings.cs
+++ b/src/Graphics/Bindings.cs
@@ -1675,7 +1675,8 @@ internal static partial class IRO
 	public static partial IntPtr IRO_Compress(
 		IntPtr data,
 		uint dataLength,
-		out uint decodedLength
+		int compressionLevel,
+		out uint outLength
 	);
 
 	[LibraryImport(nativeLibName)]

--- a/src/Graphics/Bindings.cs
+++ b/src/Graphics/Bindings.cs
@@ -1675,15 +1675,16 @@ internal static partial class IRO
 	public static partial IntPtr IRO_Compress(
 		IntPtr data,
 		uint dataLength,
-		out uint outLength
+		out uint decodedLength
 	);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr IRO_Decompress(
-		IntPtr data,
-		uint dataLength,
-		out uint outLength
+	public static partial SDLBool IRO_Decompress(
+		IntPtr encodedBuffer,
+		IntPtr decodedBuffer,
+		uint encodedLength,
+		uint decodedLength
 	);
 
 	[LibraryImport(nativeLibName)]

--- a/src/Graphics/ImageUtils.cs
+++ b/src/Graphics/ImageUtils.cs
@@ -205,13 +205,14 @@ public static class ImageUtils
 	/// <param name="compressedData">A span of zlib-encoded data.</param>
 	/// <param name="decompressedLength">Filled with the length of the decoded data.</param>
 	/// <returns></returns>
-	public static unsafe IntPtr DecompressBuffer(
+	public static unsafe bool Decompress(
 		ReadOnlySpan<byte> compressedData,
-		out uint decompressedLength
+		ReadOnlySpan<byte> destination
 	) {
-		fixed (byte *ptr = compressedData)
+		fixed (byte *src = compressedData)
+		fixed (byte *dest = destination)
 		{
-			return IRO.IRO_Decompress((nint) ptr, (uint) compressedData.Length, out decompressedLength);
+			return IRO.IRO_Decompress((nint) src, (nint) dest, (uint) compressedData.Length, (uint) destination.Length);
 		}
 	}
 

--- a/src/Graphics/ImageUtils.cs
+++ b/src/Graphics/ImageUtils.cs
@@ -177,9 +177,47 @@ public static class ImageUtils
 		return pngBuffer;
 	}
 
-	public static unsafe void FreePNGBuffer(IntPtr buffer)
+	/// <summary>
+	/// Compressed data using zlib encoding.
+	/// Returns an allocated buffer of encoded data.
+	/// You must free the buffer with FreeBufferData when you are done with the data.
+	/// Returns IntPtr.Zero if compression failed.
+	/// </summary>
+	/// <param name="buffer">A span of data.</param>
+	/// <param name="compressedLength">Filled with the length of the encoded data.</param>
+	/// <returns></returns>
+	public static unsafe IntPtr CompressBuffer(
+		ReadOnlySpan<byte> buffer,
+		out uint compressedLength
+	) {
+		fixed (byte *ptr = buffer)
+		{
+			return IRO.IRO_Compress((nint) ptr, (uint) buffer.Length, out compressedLength);
+		}
+	}
+
+	/// <summary>
+	/// Decompresses zlib-encoded data.
+	/// Returns an allocated buffer of decoded data.
+	/// You must free the buffer with FreeBufferData when you are done with the data.
+	/// Returns IntPtr.Zero if decompression failed.
+	/// </summary>
+	/// <param name="compressedData">A span of zlib-encoded data.</param>
+	/// <param name="decompressedLength">Filled with the length of the decoded data.</param>
+	/// <returns></returns>
+	public static unsafe IntPtr DecompressBuffer(
+		ReadOnlySpan<byte> compressedData,
+		out uint decompressedLength
+	) {
+		fixed (byte *ptr = compressedData)
+		{
+			return IRO.IRO_Decompress((nint) ptr, (uint) compressedData.Length, out decompressedLength);
+		}
+	}
+
+	public static unsafe void FreeBufferData(IntPtr buffer)
 	{
-		SDL.SDL_free(buffer);
+		IRO.IRO_FreeBuffer(buffer);
 	}
 
 	// DDS loading extension, based on MojoDDS

--- a/src/Graphics/ImageUtils.cs
+++ b/src/Graphics/ImageUtils.cs
@@ -184,15 +184,17 @@ public static class ImageUtils
 	/// Returns IntPtr.Zero if compression failed.
 	/// </summary>
 	/// <param name="buffer">A span of data.</param>
+	/// <param name="compressionLevel">1 is highest speed, 9 is highest compression factor.</param>
 	/// <param name="compressedLength">Filled with the length of the encoded data.</param>
 	/// <returns></returns>
-	public static unsafe IntPtr CompressBuffer(
+	public static unsafe IntPtr Compress(
 		ReadOnlySpan<byte> buffer,
+		int compressionLevel,
 		out uint compressedLength
 	) {
 		fixed (byte *ptr = buffer)
 		{
-			return IRO.IRO_Compress((nint) ptr, (uint) buffer.Length, out compressedLength);
+			return IRO.IRO_Compress((nint) ptr, (uint) buffer.Length, compressionLevel, out compressedLength);
 		}
 	}
 


### PR DESCRIPTION
It's nice to be able to compress / decompress DDS files since they are just plain binary data, so this API enables that.