### PR TITLE
Fix stack overflow when binding fragment storage buffers

### DIFF
--- a/src/Graphics/RenderPass.cs
+++ b/src/Graphics/RenderPass.cs
@@ -270,7 +270,7 @@ public class RenderPass
 	/// Binds storage buffers to the fragment shader starting at slot 0.
 	/// </summary>
 	/// <param name="buffers">The buffers to bind.</param>
-	public void BindFragmentStorageBuffers(params Span<Buffer> buffers) => BindFragmentStorageBuffers(buffers);
+	public void BindFragmentStorageBuffers(params Span<Buffer> buffers) => BindFragmentStorageBuffers(0, buffers);
 
 	/// <summary>
 	/// Draws using a vertex buffer and an index buffer.


### PR DESCRIPTION
public void BindFragmentStorageBuffers(params Span<Buffer> buffers) calls itself resulting in a stack overflow. 
Pass through to the method accepting a slot id