### PR TITLE
Remove now-irrelevant MAX_DELTA_TIME

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -21,7 +21,6 @@ namespace MoonWorks
 	{
 		public AppInfo AppInfo { get; }
 
-		public TimeSpan MAX_DELTA_TIME = TimeSpan.FromMilliseconds(100);
 		public FramePacingSettings FramePacingSettings { get; private set; }
 
 		private bool quit = false;


### PR DESCRIPTION
It was recently phased out of use in favor of `FramePacingSettings.MaxUpdatesPerTick`.