### PR TITLE
Process system events before drawing

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -357,8 +357,11 @@ namespace MoonWorks
 			// Gather and process system events before drawing.
 			// This is to handle changes to the window, to ensure rendering info is up-to-date.
 			// We could've missed such an update during busy game update loops, especially when catching up.
-			GatherSDLEvents();
-			ProcessSystemEvents();
+			if (processEvents)
+			{
+				GatherSDLEvents();
+				ProcessSystemEvents();
+			}
 
 			// Timestep alpha should be 0 if we are in latency-optimized mode.
 			var alpha = FramePacingSettings.Mode == FramePacingMode.LatencyOptimized ?


### PR DESCRIPTION
This is useful so that users have the most up-to-date information regarding the window.

For example, without this, it's possible for the `Window` class' `SizeChangeCallback` to not be called before the Draw function, which could cause a crash if the user's Draw function assumes that the swapchain's width/height are the same as the last reported values from the `SizeChangeCallback` / the values reported by the game's main Window (as I experienced, for a region-based blit).