### PR TITLE
Fix Inputs.OnTextInput being spammed when no inputs are made

### DIFF
--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -103,19 +103,22 @@ namespace MoonWorks.Input
 
 				button.Update(wasPressed, isDown);
 
-				if (TextInputBindings.TryGetValue(button.ScanCode, out var textIndex))
+				if (button.IsDown)
 				{
-					Inputs.OnTextInput(TextInputCharacters[(textIndex)]);
-				}
-				else if (IsDown(ScanCode.LeftControl) && button.ScanCode == ScanCode.V)
-				{
-					Inputs.OnTextInput(TextInputCharacters[6]);
-				}
+					if (TextInputBindings.TryGetValue(button.ScanCode, out var textIndex))
+					{
+						Inputs.OnTextInput(TextInputCharacters[textIndex]);
+					}
+					else if (IsDown(ScanCode.LeftControl) && button.ScanCode == ScanCode.V)
+					{
+						Inputs.OnTextInput(TextInputCharacters[6]);
+					}
 
-				if (button.IsPressed)
-				{
-					AnyPressed = true;
-					AnyPressedButton = button;
+					if (button.IsPressed)
+					{
+						AnyPressed = true;
+						AnyPressedButton = button;
+					}
 				}
 
 				events.Clear();

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -98,27 +98,40 @@ namespace MoonWorks.Input
                 {
                     wasPressed = ButtonWasPressed(timestamp, events);
 					isDown = events[^1].down;
+
+					if (isDown)
+					{
+						// First, check if the input window has text input active.
+						var mostRecentWindowID = events[^1].windowID;
+						Window.IDToWindow.TryGetValue(mostRecentWindowID, out var activeWindow);
+
+						if (activeWindow == null)
+						{
+							Logger.LogError($"Input window with ID {mostRecentWindowID} is somehow invalid.");
+						}
+						else if (activeWindow.TextInputActive)
+						{
+							// If so, handle special text input characters.
+							if (TextInputBindings.TryGetValue(button.ScanCode, out var textIndex))
+							{
+								Inputs.OnTextInput(TextInputCharacters[textIndex]);
+							}
+							else if (IsDown(ScanCode.LeftControl) && button.ScanCode == ScanCode.V)
+							{
+								Inputs.OnTextInput(TextInputCharacters[6]);
+							}
+						}
+					}
+
 					events.Clear();
                 }
 
 				button.Update(wasPressed, isDown);
 
-				if (button.IsDown)
+				if (button.IsPressed)
 				{
-					if (TextInputBindings.TryGetValue(button.ScanCode, out var textIndex))
-					{
-						Inputs.OnTextInput(TextInputCharacters[textIndex]);
-					}
-					else if (IsDown(ScanCode.LeftControl) && button.ScanCode == ScanCode.V)
-					{
-						Inputs.OnTextInput(TextInputCharacters[6]);
-					}
-
-					if (button.IsPressed)
-					{
-						AnyPressed = true;
-						AnyPressedButton = button;
-					}
+					AnyPressed = true;
+					AnyPressedButton = button;
 				}
 
 				events.Clear();


### PR DESCRIPTION
The original code doesn't check if the button is actually down; see issue #44 .

Also fixes it not checking if the window the input originated from actually has TextInputActive as true.